### PR TITLE
Correct description of BN_mask_bits

### DIFF
--- a/doc/man3/BN_set_bit.pod
+++ b/doc/man3/BN_set_bit.pod
@@ -33,7 +33,7 @@ error occurs if B<a> is shorter than B<n> bits.
 BN_is_bit_set() tests if bit B<n> in B<a> is set.
 
 BN_mask_bits() truncates B<a> to an B<n> bit number
-(C<a&=~((~0)E<gt>E<gt>n)>).  An error occurs if B<a> already is
+(C<a&=~((~0)E<lt>E<lt>n)>).  An error occurs if B<a> already is
 shorter than B<n> bits.
 
 BN_lshift() shifts B<a> left by B<n> bits and places the result in


### PR DESCRIPTION
CLA: trivial

Correct right shift to left shift.
Pseudo code `a&=~((~0)>>n)` means "get higher n-bits of a", but actually crypto lib gives lower n-bits.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
